### PR TITLE
Disable System keyboard by using the method setShowSoftInputOnFocus.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion "25.0.0"
     defaultConfig {
         applicationId "info.gargy.floatingkeyboard"
-        minSdkVersion 11
+        minSdkVersion 14
         targetSdkVersion 25
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
In that way we avoid bugs that can occur by changing input type, like problems with cursors, wrong focus and so on.
Also we disable the system keyboard once and for all for the given Edittext and not in every touch event which is overhead.
And last but not least we avoid using the hide method of InputMethodManager which is incosistent.